### PR TITLE
ci(workflows): use reusable attest-docker.yml for image attestation

### DIFF
--- a/.github/workflows/mattermost-multi-version.yml
+++ b/.github/workflows/mattermost-multi-version.yml
@@ -427,7 +427,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mattermost
       DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}

--- a/.github/workflows/mattermost-multi-version.yml
+++ b/.github/workflows/mattermost-multi-version.yml
@@ -363,130 +363,76 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
 
+      - name: Get and upload image digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          mkdir -p /tmp/image-digests
+          echo "sha256:${DIGEST}" > "/tmp/image-digests/${{ matrix.config.version }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-digest-${{ env.IMAGE_NAME }}-${{ matrix.config.version }}
+          path: /tmp/image-digests/${{ matrix.config.version }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Digests aren't available as a per-version job output because matrix job
+  # outputs collapse to a single (non-deterministic) value across instances,
+  # so each merge instance uploads its digest as an artifact and this job
+  # assembles them into a single {version: digest} JSON map.
+  collect-digests:
+    name: Collect image digests
+    runs-on: ubuntu-latest
+    if: ${{ needs.infos.outputs.has-builds == 'true' }}
+    needs:
+      - infos
+      - merge
+    outputs:
+      digests: ${{ steps.collect.outputs.DIGESTS }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: image-digest-${{ env.IMAGE_NAME }}-*
+          path: /tmp/image-digests
+          merge-multiple: true
+
+      - name: Collect digests
+        id: collect
+        run: |
+          DIGESTS='{}'
+          for f in /tmp/image-digests/*; do
+            VERSION=$(basename "$f")
+            DIGEST=$(cat "$f")
+            DIGESTS=$(echo "$DIGESTS" | jq -c --arg v "$VERSION" --arg d "$DIGEST" '. + {($v): $d}')
+          done
+          echo "DIGESTS=$DIGESTS" >> $GITHUB_OUTPUT
+
   attest:
     name: Attest ${{ matrix.config.version }}
-    runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
     needs:
       - infos
       - prepare-merge
-      - merge
+      - collect-digests
+    if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Sign latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/mattermost-multi-version.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ matrix.config.version }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "max_versions": "${{ inputs.MAX_VERSIONS }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/mattermost/mattermost",
-                "digest": {
-                  "gitCommit": "v${{ matrix.config.version }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest provenance to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mattermost
+      DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/mattermost-multi-version.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ matrix.config.version }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}","maxVersions":"${{ inputs.MAX_VERSIONS }}"},"resolvedDependencies":[{"uri":"git+https://github.com/mattermost/mattermost","digest":{"gitCommit":"v${{ matrix.config.version }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -274,7 +274,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mattermost
       DIGEST: ${{ needs.merge.outputs.digest }}

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -190,6 +190,8 @@ jobs:
     needs:
       - infos
       - build
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -253,119 +255,31 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          echo "value=sha256:${DIGEST}" >> $GITHUB_OUTPUT
+
   attest:
     name: Generate and attach attestations
-    runs-on: ubuntu-latest
-    if: ${{ needs.infos.outputs.image-status == '404' }}
     needs:
       - infos
       - merge
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to latest tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Sign latest tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/mattermost.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ needs.infos.outputs.tag }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/mattermost/mattermost",
-                "digest": {
-                  "gitCommit": "v${{ needs.infos.outputs.tag }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    if: ${{ needs.infos.outputs.image-status == '404' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mattermost
+      DIGEST: ${{ needs.merge.outputs.digest }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/mattermost.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ needs.infos.outputs.tag }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}"},"resolvedDependencies":[{"uri":"git+https://github.com/mattermost/mattermost","digest":{"gitCommit":"v${{ needs.infos.outputs.tag }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'

--- a/.github/workflows/mostlymatter-multi-version.yml
+++ b/.github/workflows/mostlymatter-multi-version.yml
@@ -485,7 +485,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mostlymatter
       DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}

--- a/.github/workflows/mostlymatter-multi-version.yml
+++ b/.github/workflows/mostlymatter-multi-version.yml
@@ -421,130 +421,76 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
 
+      - name: Get and upload image digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          mkdir -p /tmp/image-digests
+          echo "sha256:${DIGEST}" > "/tmp/image-digests/${{ matrix.config.version }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-digest-${{ env.IMAGE_NAME }}-${{ matrix.config.version }}
+          path: /tmp/image-digests/${{ matrix.config.version }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Digests aren't available as a per-version job output because matrix job
+  # outputs collapse to a single (non-deterministic) value across instances,
+  # so each merge instance uploads its digest as an artifact and this job
+  # assembles them into a single {version: digest} JSON map.
+  collect-digests:
+    name: Collect image digests
+    runs-on: ubuntu-latest
+    if: ${{ needs.infos.outputs.has-builds == 'true' }}
+    needs:
+      - infos
+      - merge
+    outputs:
+      digests: ${{ steps.collect.outputs.DIGESTS }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: image-digest-${{ env.IMAGE_NAME }}-*
+          path: /tmp/image-digests
+          merge-multiple: true
+
+      - name: Collect digests
+        id: collect
+        run: |
+          DIGESTS='{}'
+          for f in /tmp/image-digests/*; do
+            VERSION=$(basename "$f")
+            DIGEST=$(cat "$f")
+            DIGESTS=$(echo "$DIGESTS" | jq -c --arg v "$VERSION" --arg d "$DIGEST" '. + {($v): $d}')
+          done
+          echo "DIGESTS=$DIGESTS" >> $GITHUB_OUTPUT
+
   attest:
     name: Attest ${{ matrix.config.version }}
-    runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
     needs:
       - infos
       - prepare-merge
-      - merge
+      - collect-digests
+    if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Sign latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/mostlymatter-multi-version.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ matrix.config.version }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "max_versions": "${{ inputs.MAX_VERSIONS }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/mattermost/mattermost",
-                "digest": {
-                  "gitCommit": "v${{ matrix.config.version }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest provenance to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mostlymatter
+      DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/mostlymatter-multi-version.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ matrix.config.version }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}","maxVersions":"${{ inputs.MAX_VERSIONS }}"},"resolvedDependencies":[{"uri":"git+https://framagit.org/framasoft/framateam/mostlymatter","digest":{"gitCommit":"v${{ matrix.config.version }}-limitless"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'

--- a/.github/workflows/mostlymatter.yml
+++ b/.github/workflows/mostlymatter.yml
@@ -219,6 +219,8 @@ jobs:
     needs:
       - infos
       - build
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -282,119 +284,31 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          echo "value=sha256:${DIGEST}" >> $GITHUB_OUTPUT
+
   attest:
     name: Generate and attach attestations
-    runs-on: ubuntu-latest
-    if: ${{ needs.infos.outputs.image-status == '404' }}
     needs:
       - infos
       - merge
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to latest tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Sign latest tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/mostlymatter.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ needs.infos.outputs.tag }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://framagit.org/framasoft/framateam/mostlymatter",
-                "digest": {
-                  "gitCommit": "v${{ needs.infos.outputs.tag }}-limitless"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    if: ${{ needs.infos.outputs.image-status == '404' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mostlymatter
+      DIGEST: ${{ needs.merge.outputs.digest }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/mostlymatter.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ needs.infos.outputs.tag }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}"},"resolvedDependencies":[{"uri":"git+https://framagit.org/framasoft/framateam/mostlymatter","digest":{"gitCommit":"v${{ needs.infos.outputs.tag }}-limitless"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'

--- a/.github/workflows/mostlymatter.yml
+++ b/.github/workflows/mostlymatter.yml
@@ -303,7 +303,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/mostlymatter
       DIGEST: ${{ needs.merge.outputs.digest }}

--- a/.github/workflows/outline-multi-version.yml
+++ b/.github/workflows/outline-multi-version.yml
@@ -419,140 +419,79 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}
 
-  attest-base:
-    name: Attest base ${{ matrix.config.version }}
+      - name: Get and upload image digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          mkdir -p /tmp/image-digests
+          echo "sha256:${DIGEST}" > "/tmp/image-digests/${{ matrix.config.version }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-digest-${{ env.IMAGE_BASE_NAME }}-${{ matrix.config.version }}
+          path: /tmp/image-digests/${{ matrix.config.version }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Digests aren't available as a per-version job output because matrix job
+  # outputs collapse to a single (non-deterministic) value across instances,
+  # so each merge-base instance uploads its digest as an artifact and this
+  # job assembles them into a single {version: digest} JSON map.
+  collect-digests-base:
+    name: Collect base image digests
     runs-on: ubuntu-latest
     if: ${{ needs.infos.outputs.has-builds-base == 'true' }}
     needs:
       - infos
       - merge-base
+    outputs:
+      digests: ${{ steps.collect.outputs.DIGESTS }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: image-digest-${{ env.IMAGE_BASE_NAME }}-*
+          path: /tmp/image-digests
+          merge-multiple: true
+
+      - name: Collect digests
+        id: collect
+        run: |
+          DIGESTS='{}'
+          for f in /tmp/image-digests/*; do
+            VERSION=$(basename "$f")
+            DIGEST=$(cat "$f")
+            DIGESTS=$(echo "$DIGESTS" | jq -c --arg v "$VERSION" --arg d "$DIGEST" '. + {($v): $d}')
+          done
+          echo "DIGESTS=$DIGESTS" >> $GITHUB_OUTPUT
+
+  attest-base:
+    name: Attest base ${{ matrix.config.version }}
+    needs:
+      - infos
       - prepare-merge-base
+      - collect-digests-base
+    if: ${{ needs.infos.outputs.has-builds-base == 'true' }}
     permissions:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge-base.outputs.merge-matrix) }}
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
-
-      - name: Sign base image version tag
-        run: |
-          cosign sign --yes \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}
-
-      - name: Sign base image latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign sign --yes \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/outline-multi-version.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ matrix.config.version }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "max_versions": "${{ inputs.MAX_VERSIONS }}",
-                "image_type": "base"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/outline/outline",
-                "digest": {
-                  "gitCommit": "v${{ matrix.config.version }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest provenance to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/base-outline
+      DIGEST: ${{ fromJSON(needs.collect-digests-base.outputs.digests)[matrix.config.version] }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/outline-multi-version.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ matrix.config.version }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}","maxVersions":"${{ inputs.MAX_VERSIONS }}","imageType":"base"},"resolvedDependencies":[{"uri":"git+https://github.com/outline/outline","digest":{"gitCommit":"v${{ matrix.config.version }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'
 
   build:
     name: Build ${{ matrix.config.version }} / ${{ matrix.config.arch }}
@@ -747,130 +686,73 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
 
-  attest:
-    name: Attest ${{ matrix.config.version }}
+      - name: Get and upload image digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          mkdir -p /tmp/image-digests
+          echo "sha256:${DIGEST}" > "/tmp/image-digests/${{ matrix.config.version }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-digest-${{ env.IMAGE_NAME }}-${{ matrix.config.version }}
+          path: /tmp/image-digests/${{ matrix.config.version }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # See collect-digests-base for why this job exists (matrix job output collapse).
+  collect-digests:
+    name: Collect image digests
     runs-on: ubuntu-latest
     if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
     needs:
       - infos
-      - prepare-merge
       - merge
+    outputs:
+      digests: ${{ steps.collect.outputs.DIGESTS }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: image-digest-${{ env.IMAGE_NAME }}-*
+          path: /tmp/image-digests
+          merge-multiple: true
+
+      - name: Collect digests
+        id: collect
+        run: |
+          DIGESTS='{}'
+          for f in /tmp/image-digests/*; do
+            VERSION=$(basename "$f")
+            DIGEST=$(cat "$f")
+            DIGESTS=$(echo "$DIGESTS" | jq -c --arg v "$VERSION" --arg d "$DIGEST" '. + {($v): $d}')
+          done
+          echo "DIGESTS=$DIGESTS" >> $GITHUB_OUTPUT
+
+  attest:
+    name: Attest ${{ matrix.config.version }}
+    needs:
+      - infos
+      - prepare-merge
+      - collect-digests
+    if: ${{ !cancelled() && needs.infos.outputs.has-builds == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest SBOM to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Sign latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/outline-multi-version.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ matrix.config.version }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "max_versions": "${{ inputs.MAX_VERSIONS }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/outline/outline",
-                "digest": {
-                  "gitCommit": "v${{ matrix.config.version }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ matrix.config.version }}
-
-      - name: Attest provenance to latest tag
-        if: ${{ matrix.config.is_latest }}
-        run: |
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/outline
+      DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/outline-multi-version.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ matrix.config.version }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}","maxVersions":"${{ inputs.MAX_VERSIONS }}"},"resolvedDependencies":[{"uri":"git+https://github.com/outline/outline","digest":{"gitCommit":"v${{ matrix.config.version }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'

--- a/.github/workflows/outline-multi-version.yml
+++ b/.github/workflows/outline-multi-version.yml
@@ -483,7 +483,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge-base.outputs.merge-matrix) }}
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/base-outline
       DIGEST: ${{ fromJSON(needs.collect-digests-base.outputs.digests)[matrix.config.version] }}
@@ -747,7 +747,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.prepare-merge.outputs.merge-matrix) }}
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/outline
       DIGEST: ${{ fromJSON(needs.collect-digests.outputs.digests)[matrix.config.version] }}

--- a/.github/workflows/outline.yml
+++ b/.github/workflows/outline.yml
@@ -280,7 +280,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/base-outline
       DIGEST: ${{ needs.merge-base.outputs.digest }}
@@ -493,7 +493,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@v0
     with:
       IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/outline
       DIGEST: ${{ needs.merge.outputs.digest }}

--- a/.github/workflows/outline.yml
+++ b/.github/workflows/outline.yml
@@ -195,6 +195,8 @@ jobs:
     needs:
       - infos
       - build-base
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -259,184 +261,34 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ steps.meta.outputs.version }}
 
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ steps.meta.outputs.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          echo "value=sha256:${DIGEST}" >> $GITHUB_OUTPUT
+
   attest-base:
     name: Generate and attach base attestations
-    runs-on: ubuntu-latest
-    if: ${{ needs.infos.outputs.image-status-base == '404' }}
     needs:
       - infos
       - merge-base
+    if: ${{ needs.infos.outputs.image-status-base == '404' }}
     permissions:
       contents: read
       packages: write
       id-token: write
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: true
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to latest tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
-
-      - name: Sign base image version tag
-        run: |
-          cosign sign --yes \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Sign base image latest tag
-        run: |
-          cosign sign --yes \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
-
-      - name: Generate and attest provenance to version tag
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+${{ github.server_url }}/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/outline.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ needs.infos.outputs.tag }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "image_type": "base"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/outline/outline",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                }
-              }
-            ]
-          }
-          EOF
-
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Generate and attest provenance to latest tag
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+${{ github.server_url }}/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/outline.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ needs.infos.outputs.tag }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}",
-                "image_type": "base"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/outline/outline",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                }
-              }
-            ]
-          }
-          EOF
-
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_BASE_NAME }}:latest
+      attestations: write
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/base-outline
+      DIGEST: ${{ needs.merge-base.outputs.digest }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/outline.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ needs.infos.outputs.tag }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}","imageType":"base"},"resolvedDependencies":[{"uri":"git+https://github.com/outline/outline","digest":{"gitCommit":"v${{ needs.infos.outputs.tag }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'
 
   build:
     name: Build application
@@ -551,6 +403,8 @@ jobs:
       - build-base
       - merge-base
       - build
+    outputs:
+      digest: ${{ steps.digest.outputs.value }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -619,119 +473,32 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
+      - name: Get image digest
+        if: ${{ needs.infos.outputs.image-status == '404' }}
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect --raw \
+            "${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}" \
+            | sha256sum | cut -d' ' -f1)
+          echo "value=sha256:${DIGEST}" >> $GITHUB_OUTPUT
+
   attest:
     name: Generate and attach attestations
-    runs-on: ubuntu-latest
-    if: ${{ needs.infos.outputs.image-status == '404' }}
     needs:
       - infos
       - merge
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ inputs.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate SBOM
-        run: |
-          trivy image \
-            --format spdx-json \
-            --output sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to version tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Attest SBOM to latest tag
-        run: |
-          cosign attest \
-            --yes \
-            --type spdxjson \
-            --predicate sbom.spdx.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Sign version tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-
-      - name: Sign latest tag
-        run: |
-          cosign sign --yes ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
-
-      - name: Generate and attest provenance
-        run: |
-          cat > provenance.json <<EOF
-          {
-            "buildType": "https://github.com/slsa-framework/slsa/blob/v1.0/provenance",
-            "builder": {
-              "id": "https://github.com/${{ github.repository }}/actions/workflows/${{ github.workflow }}"
-            },
-            "invocation": {
-              "configSource": {
-                "uri": "git+https://github.com/${{ github.repository }}",
-                "digest": {
-                  "sha1": "${{ github.sha }}"
-                },
-                "entryPoint": ".github/workflows/outline.yml"
-              },
-              "parameters": {
-                "registry": "${{ inputs.REGISTRY }}",
-                "namespace": "${{ inputs.NAMESPACE }}",
-                "version": "${{ needs.infos.outputs.tag }}",
-                "multi_arch": "${{ inputs.MULTI_ARCH }}",
-                "use_qemu": "${{ inputs.USE_QEMU }}"
-              },
-              "environment": {
-                "runner": "ubuntu-latest",
-                "arch": "$(uname -m)",
-                "os": "$(uname -s)",
-                "os_version": "$(lsb_release -d | cut -f2)",
-                "docker_version": "$(docker --version)",
-                "buildx_version": "$(docker buildx version)"
-              }
-            },
-            "metadata": {
-              "buildInvocationId": "${{ github.run_id }}",
-              "buildStartedOn": "${{ github.event.repository.updated_at }}",
-              "buildFinishedOn": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-              "completeness": {
-                "parameters": true,
-                "environment": true,
-                "materials": true
-              }
-            },
-            "materials": [
-              {
-                "uri": "git+https://github.com/outline/outline",
-                "digest": {
-                  "gitCommit": "v${{ needs.infos.outputs.tag }}"
-                }
-              }
-            ]
-          }
-          EOF
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ needs.infos.outputs.tag }}
-          
-          cosign attest \
-            --yes \
-            --type slsaprovenance \
-            --predicate provenance.json \
-            ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/${{ env.IMAGE_NAME }}:latest
+    if: ${{ needs.infos.outputs.image-status == '404' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: this-is-tobi/github-workflows/.github/workflows/attest-docker.yml@1b948c7bb03d3dde4684983dfe4efb4685d0a925
+    with:
+      IMAGE_NAME: ${{ inputs.REGISTRY }}/${{ inputs.NAMESPACE }}/outline
+      DIGEST: ${{ needs.merge.outputs.digest }}
+      SIGN: true
+      SBOM: true
+      PROVENANCE: true
+      PROVENANCE_PREDICATE_TYPE: https://slsa.dev/provenance/v1
+      PROVENANCE_PREDICATE: '{"buildDefinition":{"buildType":"https://github.com/${{ github.repository }}/blob/main/.github/workflows/outline.yml","externalParameters":{"registry":"${{ inputs.REGISTRY }}","namespace":"${{ inputs.NAMESPACE }}","version":"${{ needs.infos.outputs.tag }}","multiArch":"${{ inputs.MULTI_ARCH }}","useQemu":"${{ inputs.USE_QEMU }}"},"resolvedDependencies":[{"uri":"git+https://github.com/outline/outline","digest":{"gitCommit":"v${{ needs.infos.outputs.tag }}"}}]},"runDetails":{"builder":{"id":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"},"metadata":{"invocationId":"${{ github.run_id }}"}}}'


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `cosign-installer` + `cosign sign`/`cosign attest` CLI steps in every attest job (mattermost, mostlymatter, outline, and their `-multi-version` variants) with a call to [`this-is-tobi/github-workflows`'s `attest-docker.yml`](https://github.com/this-is-tobi/github-workflows/blob/main/.github/workflows/attest-docker.yml) (built on `actions/attest`), pinned to `@v0` matching the existing convention (`build-docker.yml` already references `attest-docker.yml@v0`).
- This is also the fix for the CI failure in [run 29019664996](https://github.com/this-is-tobi/multiarch-mirror/actions/runs/29019664996): a raw `cosign attest` call failed with `fetching ambient OIDC credentials: invalid character 'u' ...` — a transient GitHub OIDC hiccup (the same commit succeeded on the next scheduled run 6h later with no changes). `actions/attest` goes through GitHub's own maintained OIDC/Sigstore path instead of a hand-rolled one.
- Attestations now target the image **digest** (via a new `docker buildx imagetools inspect --raw | sha256sum` step) instead of a mutable tag — this removes cosign's own `"uses a tag, not a digest"` warning, and means a single attest call now covers both the version tag and `latest` when they resolve to the same digest (dropped the duplicate "attest/sign to latest tag" steps).
- Multi-version workflows (`*-multi-version.yml`) add a small `collect-digests`/`collect-digests-base` job per image chain: matrix job outputs collapse to one arbitrary value across instances, so each `merge` matrix leg uploads its digest as an artifact and this job reassembles them into a `{version: digest}` map for the `attest` matrix to index by `matrix.config.version`.
- Fixes a pre-existing bug in `mostlymatter-multi-version.yml`: its SLSA provenance `materials` still pointed at `git+https://github.com/mattermost/mattermost` (leftover from before the upstream-repo-label fix in f764378) instead of the real `framagit.org/framasoft/framateam/mostlymatter` source that `mostlymatter.yml` already used.
- Net: 6 files changed, -631 lines.

## Depends on
this-is-tobi/github-workflows#27 — adds the `SIGN` and `PROVENANCE_PREDICATE_TYPE`/`PROVENANCE_PREDICATE` inputs this branch relies on. `v0` currently points at a release that predates that PR, so it needs to merge and release-please needs to cut a new release (moving `v0`) before this workflow will actually resolve those inputs.

## Test plan
- [x] Merge & release this-is-tobi/github-workflows#27 first (so `v0` picks up `SIGN`/`PROVENANCE_PREDICATE_TYPE`/`PROVENANCE_PREDICATE`)
- [ ] Run `workflow_dispatch` on one single-version workflow (e.g. `mattermost.yml`) and confirm: build → merge → attest all succeed, image is signed (`cosign verify`), SBOM + provenance attestations show up on the digest
- [ ] Run `workflow_dispatch` on one multi-version workflow (e.g. `outline-multi-version.yml`) and confirm the `collect-digests`/`collect-digests-base` jobs correctly map digests per version and every version's attest job gets the right digest