### PR TITLE
fix(workflows): grant attestations: write permission for attest-docker.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
@@ -90,6 +91,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
@@ -106,6 +108,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
@@ -121,6 +124,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
@@ -137,6 +141,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}
@@ -152,6 +157,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     with:
       REGISTRY: ${{ needs.expose-vars.outputs.REGISTRY }}
       NAMESPACE: ${{ needs.expose-vars.outputs.NAMESPACE }}

--- a/.github/workflows/mattermost-multi-version.yml
+++ b/.github/workflows/mattermost-multi-version.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   packages: write
   id-token: write  # Required for cosign keyless signing
+  attestations: write
 
 env:
   IMAGE_NAME: mattermost

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -42,6 +42,7 @@ permissions:
   contents: read
   packages: write
   id-token: write  # Required for cosign keyless signing
+  attestations: write
 
 env:
   IMAGE_NAME: mattermost

--- a/.github/workflows/mostlymatter-multi-version.yml
+++ b/.github/workflows/mostlymatter-multi-version.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 env:
   IMAGE_NAME: mostlymatter

--- a/.github/workflows/mostlymatter.yml
+++ b/.github/workflows/mostlymatter.yml
@@ -42,6 +42,7 @@ permissions:
   contents: read
   packages: write
   id-token: write  # Required for cosign keyless signing
+  attestations: write
 
 env:
   IMAGE_NAME: mostlymatter

--- a/.github/workflows/outline-multi-version.yml
+++ b/.github/workflows/outline-multi-version.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 env:
   IMAGE_BASE_NAME: base-outline

--- a/.github/workflows/outline.yml
+++ b/.github/workflows/outline.yml
@@ -42,6 +42,7 @@ permissions:
   contents: read
   packages: write
   id-token: write  # Required for cosign keyless signing
+  attestations: write
 
 env:
   IMAGE_BASE_NAME: base-outline


### PR DESCRIPTION
## Summary
Fixes the CI failure from [run 29357781065](https://github.com/this-is-tobi/multiarch-mirror/actions/runs/29357781065):

```
The workflow is not valid. .github/workflows/build.yml (Line: 69, Col: 3):
Error calling workflow '.../mattermost.yml@...'. The nested job 'attest' is
requesting 'attestations: write', but is only allowed 'attestations: none'.
```

## Why
Permissions granted to a nested reusable workflow call can never exceed what its caller was granted. Each mirror workflow's `attest` job calls the reusable `attest-docker.yml`, which needs `attestations: write` — but:
- `build.yml`'s job-level `permissions:` for each `uses: ./.github/workflows/*.yml` call only listed `contents`, `packages`, `id-token` (no `attestations`).
- Each mirror workflow's own top-level `permissions:` (used when triggered directly via `workflow_dispatch`) had the same gap.

Both levels silently capped the nested call down to `attestations: none`.

## Changes
Added `attestations: write` to:
- All 6 job-level `permissions:` blocks in `build.yml`
- The top-level `permissions:` block in each of the 6 mirror workflows

## Test plan
- [ ] Run `workflow_dispatch` on `build.yml` and confirm the attest jobs no longer fail workflow validation