### PR TITLE
docs(ghcr): encode the registry token without wrapping

### DIFF
--- a/docs/03-adding-applications.md
+++ b/docs/03-adding-applications.md
@@ -210,8 +210,13 @@ jobs:
 
       - name: Check if image already exists
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
+          # `base64` wraps at 76 columns by default, which would split the
+          # header value across lines, and `echo` would append a newline to the
+          # token before it is encoded.
+          TOKEN=$(printf '%s' "$GH_TOKEN" | base64 -w0)
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${TOKEN}" \
             https://ghcr.io/v2/${{ inputs.NAMESPACE }}/myapp/manifests/${{ steps.release.outputs.tag }})

--- a/docs/05-troubleshooting.md
+++ b/docs/05-troubleshooting.md
@@ -67,12 +67,21 @@ Latest release:
 2. **Check authentication:**
    ```yaml
    - name: Check image exists
+     env:
+       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      run: |
-       TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
+       TOKEN=$(printf '%s' "$GH_TOKEN" | base64 -w0)
        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
          -H "Authorization: Bearer ${TOKEN}" \
          https://ghcr.io/v2/${{ inputs.NAMESPACE }}/myapp/manifests/${{ steps.release.outputs.tag }})
    ```
+
+   Encode with `printf` and `base64 -w0`, not `echo ... | base64`. `echo` appends
+   a newline to the token before encoding, and `base64` wraps its output at 76
+   columns — harmless for a short token, but `GITHUB_TOKEN` is being migrated to
+   a ~520 character format that encodes to several wrapped lines and produces a
+   malformed `Authorization` header. See the
+   [changelog](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/).
 
 3. **Alternative method using docker:**
    ```yaml


### PR DESCRIPTION
## Context

GitHub is migrating GitHub App installation tokens — including the Actions `GITHUB_TOKEN` — from the current ~40 character opaque format to a stateless JWT of roughly 520 characters ([changelog](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/)).

I swept the repo for code that assumes the token's length or character set. The workflows are all clean — they forward the token into `Authorization` headers and `--password-stdin`, both length-agnostic. The one exception is the image-exists snippet in the docs.

## Problem

Both copies of the documented GHCR check do:

```sh
TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
```

`base64` wraps its output at 76 columns. That is invisible today only because the encoded token happens to fit on one line. Measured with GNU coreutils 9.11:

| token | encoded output |
| ----- | -------------- |
| 40 chars (current) | 1 line — works |
| 520 chars (new format) | **10 lines** — header contains newlines |

Once the new format reaches this repo, `Authorization: Bearer ${TOKEN}` becomes a malformed multi-line header and the check fails. Because the step only records an HTTP status, the failure surfaces as a wrong `image-status` rather than an error — builds silently skip or rebuild.

`echo` was also appending a newline to the token before encoding it.

## Change

Docs only — no workflow in this repo uses the pattern; the real ones use `docker buildx imagetools`. This is a copy-paste snippet, so the fix matters for anyone lifting it.

```sh
TOKEN=$(printf '%s' "$GH_TOKEN" | base64 -w0)
```

- `printf '%s'` drops the trailing newline.
- `-w0` disables wrapping.
- The secret is read from `env:` rather than interpolated into the shell, which also avoids expression-injection into `run:`.

Verified the round-trip is byte-exact for a 520 character input.