### PR TITLE
ci(renovate): add config to track reusable workflow updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "semanticCommits": "enabled",
+  "packageRules": [
+    {
+      "description": "This repo ships no package, so the config:recommended default of 'chore(deps)' would prefix every PR here without carrying any signal. Workflow bumps are CI changes, matching the existing 'ci(workflows):' history.",
+      "matchManagers": ["github-actions"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "workflows"
+    },
+    {
+      "description": "Own reusable workflows are referenced by the floating v0 tag. A tag that never moves is invisible to Renovate - only the digest pin added by helpers:pinGitHubActionDigests turns a v0.x release into a visible update, and the '# v0' comment it keeps alongside preserves the readable major. Grouped so every workflow calling into github-workflows moves in one PR instead of drifting apart.",
+      "matchDepNames": ["this-is-tobi/github-workflows"],
+      "groupName": "reusable workflows"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Renovate is already installed on this repo, and its onboarding PR (#7) proposes a bare `config:recommended`. That config would never surface an update for `this-is-tobi/github-workflows`.

The reason: the reusable workflows are referenced by the floating `v0` tag, and a tag that never moves is invisible to Renovate. A local dry run against the current workflows confirms it — **9 PRs proposed, none for `github-workflows`**.

## What

Adds `renovate.json` with `helpers:pinGitHubActionDigests`, which pins the ref to a digest. Unlike the tag, the digest *does* move on every `v0.x` release, so upgrades become visible. Same mechanism the [tools](https://github.com/this-is-tobi/tools/blob/main/renovate.json) repo uses.

Two package rules on top:

- **`ci(workflows)` commit prefix** — matches existing history. This repo ships no package, so `config:recommended`'s `chore(deps)` would prefix every PR here without carrying any signal.
- **grouping** — the six workflows calling `attest-docker.yml` move in one PR instead of drifting apart.

The `customManagers` and per-path rules from tools' config are intentionally dropped: they track `ARG *_VERSION` pins and base images under `docker/utils/**`, and this repo has no Dockerfiles — upstream versions are discovered at runtime from `apps/*/matrix.json` and registry checks.

## Note on b32bb83

This reverses b32bb83, which moved `attest-docker.yml` from a SHA back to `@v0` for readability. Renovate's replace template keeps the tag as a trailing comment (`@f24e5efa... # v0`), so the readable major survives the pin — the concern behind that commit still holds.

## Verification

Validated with `renovate-config-validator`, then dry-run locally (`--platform=local`, Renovate 44.33.2) against the real workflows:

- `depName` resolves to exactly `this-is-tobi/github-workflows`, so `matchDepNames` matches
- produces `updateType: pinDigest` → `f24e5efaa49770953f5a527a46b73e0cc2e1599c` — the same commit `tools` is already pinned to, so both repos converge
- lands on branch `renovate/reusable-workflows`, confirming the group applies

Merging this closes #7 (Renovate auto-closes the onboarding PR once a config exists on the default branch).